### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: Validate
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/BJReplay/EPA_AirQuality_HA/security/code-scanning/2](https://github.com/BJReplay/EPA_AirQuality_HA/security/code-scanning/2)

To fix the problem, we need to add a `permissions` block at the root level of the workflow or within the specific job (`validate-hacs`). Since the workflow only contains one job, adding a root-level `permissions` block is preferred for simplicity. The permissions will be set to `contents: read`, which is likely sufficient for this workflow. If the job explicitly requires additional permissions (e.g., `pull-requests: write`), they can be added accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
